### PR TITLE
Fix build step by using ansible escalation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,8 +46,8 @@
     register: checkout
 
   - name: build drachtio-server
-    shell: ./autogen.sh && mkdir -p build && cd $_ && ../configure CPPFLAGS='-DNDEBUG' && make && sudo make install
-    become: no
+    shell: ./autogen.sh && mkdir -p build && cd $_ && ../configure CPPFLAGS='-DNDEBUG' && make && make install
+    become: yes
     args:
       executable: /bin/bash
       chdir: /usr/local/src/drachtio-server/


### PR DESCRIPTION
Users that require a password for sudo would hang on the password
prompt. This changes the step to use ansible's 'become user' escalation
to execute this step instead of an explicit sudo to resolve this"